### PR TITLE
Remove status badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # TOS TLDR
 
-[![CI](https://github.com/lchin21/Shell-Hacks-2024/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/lchin21/Shell-Hacks-2024/actions/workflows/main.yml)
-
 We are building a Chrome Extension that the user can activate to detect the sections of their terms of service that are red flags deemed as predatory to the user.
 
 ## Team Members


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change involves removing the CI badge from the top of the document.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-L4): Removed the CI badge from the top of the document.